### PR TITLE
Add option to use universal vs app scheme links when possible

### DIFF
--- a/Sources/Web3Modal/Core/Web3Modal.swift
+++ b/Sources/Web3Modal/Core/Web3Modal.swift
@@ -75,6 +75,7 @@ public class Web3Modal {
         let excludedWalletIds: [String]
         let customWallets: [Wallet]
         let coinbaseEnabled: Bool
+        let preferUniversalLinks: Bool
 
         let onError: (Error) -> Void
     }
@@ -97,6 +98,7 @@ public class Web3Modal {
         excludedWalletIds: [String] = [],
         customWallets: [Wallet] = [],
         coinbaseEnabled: Bool = true,
+        preferUniversalLinks: Bool = false,
         onError: @escaping (Error) -> Void = { _ in }
     ) {
         Pair.configure(metadata: metadata)
@@ -110,6 +112,7 @@ public class Web3Modal {
             excludedWalletIds: excludedWalletIds,
             customWallets: customWallets,
             coinbaseEnabled: coinbaseEnabled,
+            preferUniversalLinks: preferUniversalLinks,
             onError: onError
         )
         
@@ -119,6 +122,7 @@ public class Web3Modal {
         let signInteractor = SignInteractor(store: store)
         let blockchainApiInteractor = BlockchainAPIInteractor(store: store)
         
+        store.preferUniversalLinks = preferUniversalLinks
         store.customWallets = customWallets
         
         configureCoinbaseIfNeeded(
@@ -154,7 +158,11 @@ public class Web3Modal {
     ) {
         guard Web3Modal.config.coinbaseEnabled else { return }
         
-        if let redirectLink = metadata.redirect?.universal ?? metadata.redirect?.native {
+        if let redirectLink = if store.preferUniversalLinks {
+            metadata.redirect?.universal ?? metadata.redirect?.native
+        } else {
+            metadata.redirect?.native ?? metadata.redirect?.universal
+        } {
             CoinbaseWalletSDK.configure(callback: URL(string: redirectLink)!)
         } else {
             CoinbaseWalletSDK.configure(

--- a/Sources/Web3Modal/Core/Web3Modal.swift
+++ b/Sources/Web3Modal/Core/Web3Modal.swift
@@ -208,6 +208,9 @@ public class Web3Modal {
                             })
                         
                             store.selectedChain = matchingChain
+                        
+                            instance.coinbaseConnectedSubject.send()
+                        
                         case .failure(let error):
                             store.toast = .init(style: .error, message: error.localizedDescription)
                     }

--- a/Sources/Web3Modal/Core/Web3ModalClient.swift
+++ b/Sources/Web3Modal/Core/Web3ModalClient.swift
@@ -350,12 +350,24 @@ public class Web3ModalClient {
     public func launchCurrentWallet() {
         guard
             let session = store.session,
-            let urlString = session.peer.redirect?.native ?? session.peer.redirect?.universal,
+            let urlString = if store.preferUniversalLinks {
+                session.peer.redirect?.universal ?? session.peer.redirect?.native
+            } else {
+                session.peer.redirect?.native ?? session.peer.redirect?.universal
+            },
             let url = URL(string: urlString)
-        else { return }
+        else {
+            self.store.toast = .init(style: .error, message: "Invalid redirect URL")
+            return
+        }
         
+        let isHttp: Bool = url.scheme?.lowercased().hasPrefix("http") == true
         DispatchQueue.main.async {
-            UIApplication.shared.open(url, completionHandler: nil)
+            UIApplication.shared.open(url, options: [.universalLinksOnly: isHttp]) { result in
+                if !result {
+                    self.store.toast = .init(style: .error, message: "Failed to open wallet")
+                }
+            }
         }
     }
     

--- a/Sources/Web3Modal/Core/Web3ModalClient.swift
+++ b/Sources/Web3Modal/Core/Web3ModalClient.swift
@@ -59,6 +59,7 @@ public class Web3ModalClient {
     }
     
     public var coinbaseResponseSubject = PassthroughSubject<W3MResponse, Never>()
+    public var coinbaseConnectedSubject = PassthroughSubject<Void, Never>()
     
     /// Publisher that sends web socket connection status
     public var socketConnectionStatusPublisher: AnyPublisher<SocketConnectionStatus, Never> {
@@ -318,6 +319,10 @@ public class Web3ModalClient {
     /// - Note: Will unsubscribe from all topics
     public func cleanup() async throws {
         do {
+            store.session = nil
+            store.account = nil
+            store.balance = nil
+            store.identity = nil
             try await signClient.cleanup()
         } catch {
             Web3Modal.config.onError(error)

--- a/Sources/Web3Modal/Screens/ChainSwitch/NetworkDetail/NetworkDetailViewModel.swift
+++ b/Sources/Web3Modal/Screens/ChainSwitch/NetworkDetail/NetworkDetailViewModel.swift
@@ -117,7 +117,11 @@ final class NetworkDetailViewModel: ObservableObject {
         guard let session = store.session else { return }
         
         if
-            let urlString = session.peer.redirect?.native ?? session.peer.redirect?.universal,
+            let urlString = if store.preferUniversalLinks {
+                session.peer.redirect?.universal ?? session.peer.redirect?.native
+            } else {
+                session.peer.redirect?.native ?? session.peer.redirect?.universal
+            },
             let url = URL(string: urlString)
         {
             DispatchQueue.main.async {

--- a/Sources/Web3Modal/Store.swift
+++ b/Sources/Web3Modal/Store.swift
@@ -67,6 +67,8 @@ class Store: ObservableObject {
     @Published var chainImages: [String: UIImage] = [:]
     
     @Published var toast: Toast? = nil
+    
+    var preferUniversalLinks: Bool = false
 }
 
 struct W3MAccount: Codable {


### PR DESCRIPTION
# Description

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

Resolves #64

## How Has This Been Tested?
1. Supply a universal and native link in the AppMetadata
2. Toggle the `preferUniversalLinks` flag
3. Launch a wallet
